### PR TITLE
Fix issue when zooming out

### DIFF
--- a/Assets/Scripts/Camera/CameraControlerCam.cs
+++ b/Assets/Scripts/Camera/CameraControlerCam.cs
@@ -60,6 +60,7 @@ public partial class CameraControler : MonoBehaviour {
 				}
 			}
 		}
+		TargetLocalCamPos.y = Mathf.Clamp(TargetLocalCamPos.y, MinDistance, MaxDistance);
 
 		//LastLocalCamPos = Vector3.Lerp(LastLocalCamPos, TargetLocalCamPos, Time.unscaledDeltaTime * SmoothZoom);
 		Vector3 Velocity = Vector3.zero;


### PR DESCRIPTION
When the user zoomed out fast enough, sometimes the camera would go too far. What would happen is that the map became invisible and the user couldn't zoom back in. The user would have to restart the editor and open the map again to fix it.
This change clamps the range the camera moves along the y-axis in hard.