### PR TITLE
Fixed units not showing in editor

### DIFF
--- a/Assets/Scripts/Ozone SCMAP Code/GetGamedataFile/GetGamedataFile_Unit.cs
+++ b/Assets/Scripts/Ozone SCMAP Code/GetGamedataFile/GetGamedataFile_Unit.cs
@@ -214,7 +214,7 @@ public partial struct GetGamedataFile
 			return CreateEmptyUnit(LocalPath);
 		}
 
-		BluePrintString = BluePrintString.Replace("UnitBlueprint {", "UnitBlueprint = {");
+		BluePrintString = BluePrintString.Replace("UnitBlueprint{", "UnitBlueprint = {");
 
 		string[] PathSplit = LocalPath.Split('/');
 		GameObject NewUnit = new GameObject(PathSplit[PathSplit.Length - 1].Replace(".bp", ""));


### PR DESCRIPTION
Fixed https://github.com/ozonexo3/FAForeverMapEditor/issues/155
I think there were some changes in .NET that now makes System.Text.Encoding.UTF8.GetString(Bytes) return UnitBlueprint without space